### PR TITLE
Trim and remove carriage returns from keys.

### DIFF
--- a/tracker.py
+++ b/tracker.py
@@ -25,6 +25,14 @@ token = loadKeyFile('keys/token')
 token_secret = loadKeyFile('keys/token_secret')
 consumer_key = loadKeyFile('keys/consumer_key')
 consumer_secret = loadKeyFile('keys/consumer_secret')
+
+# Remove any extra spaces or carriage returns that may have made there way into the key files.
+# These lines would only be needed up until the point these keys are moved into a configuration file.
+token = token.replace('\n', ' ').replace('\r', '').strip()
+token_secret = token_secret.replace('\n', ' ').replace('\r', '').strip()
+consumer_key = consumer_key.replace('\n', ' ').replace('\r', '').strip()
+consumer_secret = consumer_secret.replace('\n', ' ').replace('\r', '').strip()
+
 twit = Twitter(auth=(OAuth(token, token_secret, consumer_key, consumer_secret)))
 
 # Given an aircraft 'a' tweet.  


### PR DESCRIPTION
When creating the key files I used echo to create the key files.

`echo SOME_TWITTER_TOKEN_GOES_HERE > keys/token`

Apparently doing so added a carriage return to the end of the file so when the file was read into the proper variable the carriage return ended up being part of the variables value. This was causing authentication problem when trying to authenticate with Twitter.

Anyways the additional lines trim the string then remove any carriage returns which may be present in the value. Please note these lines will only be needed temporarily until the point a configuration file storing such values has been added to the project.