### PR TITLE
Add support for anonymized ICAOs

### DIFF
--- a/config.sample.ini
+++ b/config.sample.ini
@@ -1,4 +1,9 @@
 [abovetustin]
+driver = dump1090
+data_url = http://localhost/dump1090/data/aircraft.json
+map_url = http://localhost/dump1090/gmap.html
+request_timeout = 60
+
 ; An airplane is only tracked and tweeted when it enters the "alarm area" the alarm area
 ; is defined by the "distance_alarm" in miles, and the elevation_alarm in degrees from
 ; the horizon. If any airplane travels closer than the distance_alarm or higher than the
@@ -52,11 +57,6 @@ tweet_template =#${flight} : ${dist_mi} mi away @ ${alt_ft} ft and ${el}° frm h
 fa_tweet_template =#${flight} : #${orig_alt} (${orig_city}) to #${dest_alt} (${dest_city}). ${dist_mi} mi away @ ${alt_ft} ft and ${el}° frm hrzn, heading ${heading} @ ${speed_mph}mi/h ${time}.
 
 default_hashtags =#AboveTustin #RaspberryPi #ADSB #dump1090
-
-[dump1090]
-data_url = http://localhost/dump1090/data/aircraft.json
-map_url = http://localhost/dump1090/gmap.html
-request_timeout = 60
 
 [receiver]
 latitude = 33.754271

--- a/config.sample.ini
+++ b/config.sample.ini
@@ -56,6 +56,13 @@ tweet_template =#${flight} : ${dist_mi} mi away @ ${alt_ft} ft and ${el}° frm h
 ; $fa_tweet_template will replace $tweet_template when enough data is gathered from FA API call (see flightaware section below)
 fa_tweet_template =#${flight} : #${orig_alt} (${orig_city}) to #${dest_alt} (${dest_city}). ${dist_mi} mi away @ ${alt_ft} ft and ${el}° frm hrzn, heading ${heading} @ ${speed_mph}mi/h ${time}.
 
+; $anon_tweet_template will replace $tweet_template when the
+; aircraft's identification has been blocked. See
+; https://discussions.flightaware.com/t/flightaware-mlat-network-announcement/18874
+; for more information.
+
+anon_tweet_template =Anonymous aircraft: ${dist_mi} mi away @ ${alt_ft} ft and ${el}° frm hrzn, heading ${heading} @ ${speed_mph}mi/h ${time}.
+
 default_hashtags =#AboveTustin #RaspberryPi #ADSB #dump1090
 
 [receiver]

--- a/flightdata.py
+++ b/flightdata.py
@@ -30,15 +30,12 @@ from configparser import ConfigParser
 parser = ConfigParser()
 parser.read('config.ini')
 
-# Assign dump1090 variables.
-dump1090_data_url = parser.get('dump1090', 'data_url')
-
 # Assign receiver variables.
 receiver_latitude = float(parser.get('receiver', 'latitude'))
 receiver_longitude = float(parser.get('receiver', 'longitude'))
 
 class FlightData():
-    def __init__(self, data_url=dump1090_data_url, parser=None):
+    def __init__(self, data_url=None, parser=None):
         self.data_url = data_url
         self.parser = parser
         self.aircraft = None

--- a/screenshot.py
+++ b/screenshot.py
@@ -93,7 +93,7 @@ class Dump1090Display(AircraftDisplay):
         browser = webdriver.PhantomJS(desired_capabilities={'phantomjs.page.settings.resourceTimeout': '20000'})
         browser.set_window_size(abovetustin_image_width, abovetustin_image_height)
 
-        print("getting web page...")
+        print("getting web page {}".format(self.url))
         browser.set_page_load_timeout(15)
         browser.get(self.url)
 
@@ -129,12 +129,49 @@ class Dump1090Display(AircraftDisplay):
         clickOnAirplane()
         Clicks on the airplane with the name text, and then takes a screenshot
         '''
-        element = self.browser.find_elements_by_xpath("//td[text()='%s']" % text)
+        element = self.browser.find_elements_by_xpath("//td[translate(text(), 'ABCDEF', 'abcdef')='%s']" % text)
         print("number of elements found: %i" % len(element))
         if len(element) > 0:
-            print("click!")
+            print("clicking on {}!".format(text))
             element[0].click()
             time.sleep(0.5) # if we don't wait a little bit the airplane icon isn't drawn.
             return self.screenshot('tweet.png')
         else:
             print("couldn't find the object")
+
+
+class VRSDisplay(AircraftDisplay):
+    def loadmap(self):
+        '''
+        loadmap()
+        Creates a browser object and loads the webpage.
+        It sets up the map to the proper zoom level.
+
+        Returns the browser on success, None on fail.
+        '''
+        browser = webdriver.PhantomJS(desired_capabilities={'phantomjs.page.settings.resourceTimeout': '20000'})
+        browser.set_window_size(abovetustin_image_width, abovetustin_image_height)
+
+        print("getting web page {}".format(self.url))
+        browser.set_page_load_timeout(15)
+        browser.get(self.url)
+
+        # Need to wait for the page to load
+        timeout = dump1090_request_timeout
+        print ("waiting for page to load...")
+        wait = WebDriverWait(browser, timeout)
+        element = wait.until(EC.element_to_be_clickable((By.CLASS_NAME,'vrsMenu')))
+        self.browser = browser
+
+    def clickOnAirplane(self, text):
+        '''
+        clickOnAirplane()
+        Clicks on the airplane with the name text, and then takes a screenshot
+        '''
+        aircraft = self.browser.find_element_by_xpath("//td[text()='%s']" % text)
+        aircraft.click()
+        time.sleep(0.5) # if we don't wait a little bit the airplane icon isn't drawn.
+        show_on_map = self.browser.find_element_by_link_text('Show on map')
+        show_on_map.click()
+        time.sleep(3.0)
+        return self.screenshot('tweet.png')

--- a/screenshot.py
+++ b/screenshot.py
@@ -43,21 +43,58 @@ else:
 dump1090_map_url = parser.get('dump1090', 'map_url')
 dump1090_request_timeout = int(parser.get('dump1090', 'request_timeout'))
 
-def loadmap():
-    '''
-    loadmap()
-    Creates a browser object and loads the webpage.
-    It sets up the map to the proper zoom level.
 
-    Returns the browser on success, None on fail.
-    '''
-    try:
+class AircraftDisplay(object):
+    def __init__(self, url):
+        self.url = url
+        self.browser = None
+        self.loadmap()
+
+    def loadmap(self):
+        raise NotImplementedError
+
+    def reload(self):
+        self.browser.quit()
+        self.browser = None
+        self.loadmap()
+
+    def screenshot(self, name):
+        '''
+        screenshot()
+        Takes a screenshot of the browser
+        '''
+        if do_crop:
+            print('cropping screenshot')
+            #  Grab screenshot rather than saving
+            im = self.browser.get_screenshot_as_png()
+            im = Image.open(BytesIO(im))
+
+            #  Crop to specifications
+            im = im.crop((crop_x, crop_y, crop_width, crop_height))
+            im.save(name)
+        else:
+            self.browser.save_screenshot(name)
+        print("success saving screenshot: %s" % name)
+
+    def ClickOnAirplane(self, ident):
+        raise NotImplementedError
+
+
+class Dump1090Display(AircraftDisplay):
+    def loadmap(self):
+        '''
+        loadmap()
+        Creates a browser object and loads the webpage.
+        It sets up the map to the proper zoom level.
+
+        Returns the browser on success, None on fail.
+        '''
         browser = webdriver.PhantomJS(desired_capabilities={'phantomjs.page.settings.resourceTimeout': '20000'})
         browser.set_window_size(abovetustin_image_width, abovetustin_image_height)
 
-        print ("getting web page...")
+        print("getting web page...")
         browser.set_page_load_timeout(15)
-        browser.get(dump1090_map_url)
+        browser.get(self.url)
 
         # Need to wait for the page to load
         timeout = dump1090_request_timeout
@@ -84,55 +121,19 @@ def loadmap():
         zoomin.click()
         zoomin.click()
         zoomin.click()
+        self.browser = browser
 
-        return browser
-    except:
-        print("exception in loadmap()")
-        print (sys.exc_info()[0])
-        return None
-
-
-def screenshot(browser, name):
-    '''
-    screenshot()
-    Takes a screenshot of the browser
-    '''
-    try:
-        if do_crop:
-            print('cropping screenshot')
-            #  Grab screenshot rather than saving
-            im = browser.get_screenshot_as_png()
-            im = Image.open(BytesIO(im))
-
-            #  Crop to specifications
-            im = im.crop((crop_x, crop_y, crop_width, crop_height))
-            im.save(name)
-        else:
-            browser.save_screenshot(name)
-        print("success saving screnshot: %s" % name)
-        return True
-    except:
-        print("exception in screenshot()")
-        print(sys.exc_info()[0])
-    return False
-
-
-def clickOnAirplane(browser, text):
-    '''
-    clickOnAirplane()
-    Clicks on the airplane with the name text, and then takes a screenshot
-    '''
-    try:
-        element = browser.find_elements_by_xpath("//td[text()='%s']" % text)
+    def clickOnAirplane(self, text):
+        '''
+        clickOnAirplane()
+        Clicks on the airplane with the name text, and then takes a screenshot
+        '''
+        element = self.browser.find_elements_by_xpath("//td[text()='%s']" % text)
         print("number of elements found: %i" % len(element))
         if len(element) > 0:
             print("click!")
             element[0].click()
             time.sleep(0.5) # if we don't wait a little bit the airplane icon isn't drawn.
-            return screenshot(browser, 'tweet.png')
+            return self.screenshot('tweet.png')
         else:
             print("couldn't find the object")
-    except:
-        print("exception in clickOnAirplane()")
-        print (sys.exc_info()[0])
-    return False

--- a/screenshot.py
+++ b/screenshot.py
@@ -77,6 +77,7 @@ class AircraftDisplay(object):
         else:
             self.browser.save_screenshot(name)
         print("success saving screenshot: %s" % name)
+        return name
 
     def ClickOnAirplane(self, ident):
         raise NotImplementedError
@@ -137,15 +138,19 @@ class Dump1090Display(AircraftDisplay):
         clickOnAirplane()
         Clicks on the airplane with the name text, and then takes a screenshot
         '''
-        element = self.browser.find_elements_by_xpath("//td[translate(text(), 'ABCDEF', 'abcdef')='%s']" % text)
-        print("number of elements found: %i" % len(element))
-        if len(element) > 0:
-            print("clicking on {}!".format(text))
-            element[0].click()
-            time.sleep(0.5) # if we don't wait a little bit the airplane icon isn't drawn.
-            return self.screenshot('tweet.png')
-        else:
-            print("couldn't find the object")
+        try:
+            element = self.browser.find_elements_by_xpath("//td[translate(text(), 'ABCDEF', 'abcdef')='%s']" % text)
+            print("number of elements found: %i" % len(element))
+            if len(element) > 0:
+                print("clicking on {}!".format(text))
+                element[0].click()
+                time.sleep(0.5) # if we don't wait a little bit the airplane icon isn't drawn.
+                return self.screenshot('tweet.png')
+            else:
+                print("couldn't find the object")
+        except Exception as e:
+            util.error("Could not click on airplane: {}".format(e))
+            return None
 
 
 class VRSDisplay(AircraftDisplay):
@@ -176,10 +181,14 @@ class VRSDisplay(AircraftDisplay):
         clickOnAirplane()
         Clicks on the airplane with the name text, and then takes a screenshot
         '''
-        aircraft = self.browser.find_element_by_xpath("//td[text()='%s']" % text)
-        aircraft.click()
-        time.sleep(0.5) # if we don't wait a little bit the airplane icon isn't drawn.
-        show_on_map = self.browser.find_element_by_link_text('Show on map')
-        show_on_map.click()
-        time.sleep(3.0)
-        return self.screenshot('tweet.png')
+        try:
+            aircraft = self.browser.find_element_by_xpath("//td[text()='%s']" % text)
+            aircraft.click()
+            time.sleep(0.5) # if we don't wait a little bit the airplane icon isn't drawn.
+            show_on_map = self.browser.find_element_by_link_text('Show on map')
+            show_on_map.click()
+            time.sleep(3.0)
+            return self.screenshot('tweet.png')
+        except Exception as e:
+            util.error("Unable to click on airplane: {}'".format(e))
+            return None

--- a/tracker.py
+++ b/tracker.py
@@ -130,12 +130,7 @@ def Tweet(a, havescreenshot):
 if __name__ == "__main__":
 
 	lastReloadTime = time.time()
-	browser = screenshot.loadmap()
-	if browser == None:
-		print("unable to load browser!")
-	else:
-		print("browser loaded!")
-
+	display = screenshot.Dump1090Display(url=screenshot.dump1090_map_url)
 	alarms = dict() # dictonary of all aircraft that have triggered the alarm
 			# Indexed by it's hex code, each entry contains a tuple of
 			# the aircraft data at the closest position so far, and a 
@@ -149,9 +144,7 @@ if __name__ == "__main__":
 	while True:
 		if time.time() > lastReloadTime + 3600 and len(alarms) == 0:
 			print("one hour since last browser reload... reloading now")
-			if browser != None:
-				browser.quit()
-			browser = screenshot.loadmap()
+			display.reload()
 			lastReloadTime = time.time()
 
 		sleep(abovetustin_sleep_time)
@@ -201,13 +194,13 @@ if __name__ == "__main__":
 					alarms[h] = (a[0], a[1]+1)
 				else:				
 					havescreenshot = False
-					if browser != None:
+					if display != None:
 						print("time to create screenshot:")
 						hexcode = a[0].hex
 						hexcode = hexcode.replace(" ", "")
 						hexcode = hexcode.replace("~", "")
 
-						havescreenshot = screenshot.clickOnAirplane(browser, hexcode)
+						havescreenshot = display.clickOnAirplane(hexcode)
 
 					if fa_enable:
 						print("Getting FlightAware flight details")

--- a/tracker.py
+++ b/tracker.py
@@ -44,10 +44,9 @@ twit = Twitter(auth=(OAuth(twitter_access_token, twitter_access_token_secret, tw
 def Tweet(a, havescreenshot):
 	# compile the template arguments
 	templateArgs = dict()
-	templateArgs['flight'] = a.flight
-	if templateArgs['flight'] == 'N/A':
-		templateArgs['flight'] = a.hex
-	templateArgs['flight'] = templateArgs['flight'].replace(" ", "")
+	flight = a.flight or a.hex
+	flight = flight.replace(" ", "")
+	templateArgs['flight'] = flight
 	templateArgs['icao'] = a.hex
 	templateArgs['icao'] = templateArgs['icao'].replace(" ", "")
 	templateArgs['dist_mi'] = "%.1f" % a.distance
@@ -144,7 +143,7 @@ if __name__ == "__main__":
 			# the counter is incremented until we hit [abovetustin_wait_x_updates]
 			# (defined above), at which point we then Tweet
 
-	fd = flightdata.FlightData()
+	fd = flightdata.FlightData(parser=flightdata.Dump1090DataParser())
 	lastTime = fd.time
 
 	while True:
@@ -170,17 +169,13 @@ if __name__ == "__main__":
 			# if they don't have lat/lon or a heading skip them
 			if a.lat == None or a.lon == None or a.track == None:
 				continue
-
 			# check to see if it's in the alarm zone:
 			if a.distance < abovetustin_distance_alarm or a.el > abovetustin_elevation_alarm:
-
 				# add it to the current dictionary
 				current[a.hex] = a 
-
 				print("{}/{}: {}mi, {}az, {}el, {}alt, {}dB, {}seen".format(
 					a.hex, a.flight, "%.1f" % a.distance, "%.1f" % a.az, "%.1f" % a.el,
-					a.altitude, "%0.1f" % a.rssi, "%.1f" % a.seen))
-
+					a.altitude, "%0.1f" % a.rssi, "%.1f" % (a.seen or 0)))
 				if a.hex in alarms:
 					#if it's already in the alarms dict, check to see if we're closer
 					if a.distance < alarms[a.hex][0].distance:

--- a/tracker.py
+++ b/tracker.py
@@ -39,11 +39,10 @@ twitter_consumer_secret = parser.get('twitter', 'consumer_secret')
 twitter_access_token = parser.get('twitter', 'access_token')
 twitter_access_token_secret = parser.get('twitter', 'access_token_secret')
 
-
 # Login to twitter.
 twit = Twitter(auth=(OAuth(twitter_access_token, twitter_access_token_secret, twitter_consumer_key, twitter_consumer_secret)))
 
-# Given an aircraft 'a' tweet.  
+# Given an aircraft 'a' tweet.
 # If we have a screenshot, upload it to twitter with the tweet.
 def Tweet(a, havescreenshot):
 	# compile the template arguments
@@ -88,6 +87,8 @@ def Tweet(a, havescreenshot):
 			tweet = Template(parser.get('tweet', 'fa_tweet_template')).substitute(templateArgs)
 		else:
 			tweet = Template(parser.get('tweet', 'tweet_template')).substitute(templateArgs)
+	elif a.anonymized:
+		tweet = Template(parser.get('tweet', 'anon_tweet_template')).substitute(templateArgs)
 	else:
 		tweet = Template(parser.get('tweet', 'tweet_template')).substitute(templateArgs)
 	#conditional hashtags:
@@ -202,9 +203,8 @@ if __name__ == "__main__":
 						print("time to create screenshot of {}:".format(a[0]))
 						hexcode = a[0].hex
 						hexcode = hexcode.replace(" ", "")
-						hexcode = hexcode.replace("~", "")
 						havescreenshot = display.clickOnAirplane(hexcode)
-					if fa_enable:
+					if fa_enable and not a[0].anonymized:
 						print("Getting FlightAware flight details")
 						faInfo = fa_api.FlightInfo(a[0].flight, fa_username, fa_api_key)
 					else:

--- a/tracker.py
+++ b/tracker.py
@@ -167,8 +167,8 @@ if __name__ == "__main__":
 			if a.distance < abovetustin_distance_alarm or a.el > abovetustin_elevation_alarm:
 				# add it to the current dictionary
 				current[a.hex] = a 
-				print("{}/{}: {}mi, {}az, {}el, {}alt, {}dB, {}seen".format(
-					a.hex, a.flight, "%.1f" % a.distance, "%.1f" % a.az, "%.1f" % a.el,
+				print("{}: {}mi, {}az, {}el, {}alt, {}dB, {}seen".format(
+					a.ident_desc(), "%.1f" % a.distance, "%.1f" % a.az, "%.1f" % a.el,
 					a.altitude, "%0.1f" % a.rssi, "%.1f" % (a.seen or 0)))
 				if a.hex in alarms:
 					#if it's already in the alarms dict, check to see if we're closer
@@ -193,16 +193,14 @@ if __name__ == "__main__":
 			if not found:
 				if a[1] < abovetustin_wait_x_updates:
 					alarms[h] = (a[0], a[1]+1)
-				else:				
+				else:
 					havescreenshot = False
 					if display != None:
-						print("time to create screenshot:")
+						print("time to create screenshot of {}:".format(a[0]))
 						hexcode = a[0].hex
 						hexcode = hexcode.replace(" ", "")
 						hexcode = hexcode.replace("~", "")
-
 						havescreenshot = display.clickOnAirplane(hexcode)
-
 					if fa_enable:
 						print("Getting FlightAware flight details")
 						faInfo = fa_api.FlightInfo(a[0].flight, fa_username, fa_api_key)

--- a/tracker.py
+++ b/tracker.py
@@ -9,12 +9,14 @@ import traceback
 import time
 from time import sleep
 from twitter import *
-import flightdata
-import screenshot
 from configparser import ConfigParser
 from string import Template
-import geomath
+
+import datasource
 import fa_api
+import flightdata
+import geomath
+import screenshot
 
 # Read the configuration file for this application.
 parser = ConfigParser()
@@ -36,6 +38,7 @@ twitter_consumer_key = parser.get('twitter', 'consumer_key')
 twitter_consumer_secret = parser.get('twitter', 'consumer_secret')
 twitter_access_token = parser.get('twitter', 'access_token')
 twitter_access_token_secret = parser.get('twitter', 'access_token_secret')
+
 
 # Login to twitter.
 twit = Twitter(auth=(OAuth(twitter_access_token, twitter_access_token_secret, twitter_consumer_key, twitter_consumer_secret)))
@@ -131,7 +134,7 @@ def Tweet(a, havescreenshot):
 if __name__ == "__main__":
 
 	lastReloadTime = time.time()
-	display = screenshot.Dump1090Display(url=screenshot.dump1090_map_url)
+	display = datasource.get_map_source()
 	alarms = dict() # dictonary of all aircraft that have triggered the alarm
 			# Indexed by it's hex code, each entry contains a tuple of
 			# the aircraft data at the closest position so far, and a 
@@ -139,7 +142,7 @@ if __name__ == "__main__":
 			# the counter is incremented until we hit [abovetustin_wait_x_updates]
 			# (defined above), at which point we then Tweet
 
-	fd = flightdata.FlightData(parser=flightdata.Dump1090DataParser())
+	fd = datasource.get_data_source()
 	lastTime = fd.time
 
 	while True:

--- a/util.py
+++ b/util.py
@@ -1,0 +1,6 @@
+import sys
+
+
+def error(fmt, *args):
+    sys.stdout.flush()
+    sys.stderr.write((fmt % args) + '\n')


### PR DESCRIPTION
This PR adds a new `anon_tweet_template` that is used for anonymized flights, where the ICAO is meaningless.

Requires #29. Fixes #26.
